### PR TITLE
Use httpclient 5.3.1, not httpclient 5.4

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,10 @@
     "config:base",
     ":semanticCommitsDisabled"
   ],
+  "packageRules": [
+    "matchPackageNames": ["org.apache.httpcomponents.client5:http**"],
+    "allowedVersions": ["<5.4"]
+  ],
   "reviewers": [
     "team:apache-httpcomponents-client-5-api-plugin-developers"
   ],

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,9 @@
     <httpclient.version>5.3.1</httpclient.version>
     <httpcore.version>5.3.1</httpcore.version>
     <jenkins.version>2.361.4</jenkins.version>
-    <revision>${httpclient.version}</revision>
+    <!-- TODO: Revert to ${httpclient.version} once https://github.com/jenkinsci/apache-httpcomponents-client-5-api-plugin/issues/59 is fixed -->
+    <!-- <revision>${httpclient.version{</revision> -->
+    <revision>5.4</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <gitHubRepo>jenkinsci/apache-httpcomponents-client-5-api-plugin</gitHubRepo>
-    <httpclient.version>5.4</httpclient.version>
+    <httpclient.version>5.3.1</httpclient.version>
     <httpcore.version>5.3.1</httpcore.version>
     <jenkins.version>2.361.4</jenkins.version>
     <revision>${httpclient.version}</revision>


### PR DESCRIPTION
## Use httpclient 5.3.1, not httpclient 5.4

Reverts 199115451c4da86ff7d403575a57e586e270ab19 from 

* #57

The failure that Docker plugin users encounter with httpclient 5.4 when connecting to the Docker daemon over a Unix domain socket is described in:

* https://github.com/jenkinsci/docker-plugin/issues/1032

The test automation failure that happens with httpclient 5.4 is described in:

* https://github.com/jenkinsci/docker-plugin/issues/1103 

Two other issues note that there are problems in httpclient 5.4:

* #29 
* #59

Intentionally sets the plugin version to 5.4 so that a release based on this change will supersede the previous 5.4 based release that users may have installed.

Intentionally disables renovate updates to 5.4 or newer.  Once the issue is resolved in upstream, that block can be removed.

### Testing done

Automated tests pass for this plugin.  

Automated tests pass for the docker plugin with the incremental from this pull request.  Automated tests fail in the docker plugin with the httpclient 5.4 version.

Incremental build  tested in my development environment with a Docker daemon accessible over a TCP socket.  Confirmed that the switch back to httpclient 5.3.1 did not regress existing functionality over a TCP socket.

Incremental build tested in a separate environment and confirmed that I can duplicate the problem using the httpclient 5.4 release and the httpclient incremental build from this pull request fixes the issue.  The git repository that I used to record the passing and failing configuration is included as [httpclient-59.tar.gz](https://github.com/user-attachments/files/17485118/httpclient-59.tar.gz).  The username in that installation is "mwaite" and the password is "mwaite".  Run the environment with the command `bash ./README` on a Linux computer with a local Docker daemon.  Be sure that you are running from a user account that has access to Docker.

Dependent plugins include:

* [SAML](https://plugins.jenkins.io/saml/dependencies/) depends on [5.4-118.v199115451c4d](https://plugins.jenkins.io/apache-httpcomponents-client-5-api/releases/#version_5.4-118.v199115451c4d)
* [Analysis model API](https://plugins.jenkins.io/analysis-model-api/dependencies/) depends on [5.3.1-110.v77252fb_d4da_5](https://plugins.jenkins.io/apache-httpcomponents-client-5-api/releases/#version_5.3.1-110.v77252fb_d4da_5) - no issue
* [Docker API](https://plugins.jenkins.io/docker-java-api/dependencies/) depends on [5.2.1-1.0](https://plugins.jenkins.io/apache-httpcomponents-client-5-api/releases/#version_5.2.2-1.0) - no issue

Confirmed that the [most recent release of the SAML plugin](https://plugins.jenkins.io/saml/dependencies/) has a dependency on [release 
 5.4-120.v6b_5b_322da_5c4](https://github.com/jenkinsci/apache-httpcomponents-client-5-api-plugin/releases/tag/5.4-120.v6b_5b_322da_5c4).  That release requires Jenkins 2.479 or newer.  I did not find any changes in that release that depend on httpclient 5.4 features.  The downgrade from httpclient 5.4 to httpclient 5.3.1 seems safe for that plugin

The previous release (4.487.v9f1c3328f1c0) of the SAML plugin depends on 5.3.1-110.v77252fb_d4da_5 so has no issue with this proposed change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
