### PR TITLE
Fix renovate syntax error, migrate to recommended configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,12 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "automerge": true,
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommitsDisabled"
   ],
   "packageRules": [
-    "matchPackageNames": ["org.apache.httpcomponents.client5:http**"],
-    "allowedVersions": ["<5.4"]
+    {
+      "matchPackageNames": ["org.apache.httpcomponents.client5:http**"],
+      "allowedVersions": "<5.4"
+    }
   ],
   "reviewers": [
     "team:apache-httpcomponents-client-5-api-plugin-developers"


### PR DESCRIPTION
## Fix renovate syntax error, migrate to recommended configuration

The [presets-config documentation](https://docs.renovatebot.com/presets-config/) describes the "config:recommended" usage.  The migration message from the configuration validator includes that setting in the message.

Does not adopt the upgrade best practices recommended in [upgrade best practices documentation](https://docs.renovatebot.com/upgrade-best-practices/).  If that is desired, I'm happy to make that change as well.

Fixes #63

### Testing done

Tested with:

```
$ renovate-config-validator
 INFO: Validating .github/renovate.json
 INFO: Config validated successfully
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
