### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 :toclevels: 3
 :toc-title:
 
-image:https://ci.jenkins.io/job/Plugins/job/apache-httpcomponents-client-5-api-plugin/job/main/badge/icon[link="https://ci.jenkins.io/job/Plugins/job/apache-httpcomponents-client-5-api-plugin/job/main/"]
+image:https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fapache-httpcomponents-client-5-api-plugin%2Fmain[link="https://ci.jenkins.io/job/Plugins/job/apache-httpcomponents-client-5-api-plugin/job/main/"]
 image:https://github.com/jenkinsci/apache-httpcomponents-client-5-api-plugin/actions/workflows/jenkins-security-scan.yml/badge.svg[link="https://github.com/jenkinsci/apache-httpcomponents-client-5-api-plugin/actions/workflows/jenkins-security-scan.yml"]
 
 image:https://img.shields.io/jenkins/plugin/i/apache-httpcomponents-client-5-api.svg?color=blue&label=installations[link="https://stats.jenkins.io/pluginversions/apache-httpcomponents-client-5-api.html"]


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
